### PR TITLE
Add M3 retrospective and M4 norms to contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,3 +25,25 @@ Trolling, insults, derogatory comments, and political attacks
 Public or private harassment
 Ignoring privacy concerns of the community
 And other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Collaboration Retrospective and Norms
+### M3 Retrospective
+What worked
+- going through the whole milestone during Lab on Monday: create issues and assign issues to each member
+- breaking up the tasks such that each team member is responsible for one major task, and a few minor tasks (e.g. small feedback improvements, updating the changelog, etc)
+- all groupmates finished work in a timely manner
+
+What didn't work
+- two people made major changes to app.py in M3 which caused some merge conflicts
+- some team members did much more coding than others and some did much more writing than others
+- set up a recurring meeting on Thursday but don't keep to it (did check in on two occasions but on one occasion all of us just forgot)
+- some lack of communication/clarity about who was doing what, e.g. who was creating the release and submitting
+- not enough documentation (e.g. PRs were not well documented)
+
+### M4 Collaboration Norms
+For M4, we are committing to the following:
+- additional documentation, especially documenting design decisions in PR description fields
+- all PRs should to be explicitly "approved", not just leave a comment
+- increased communication and more frequent PRs to prevent merge conflicts, especially on app.py since all of us need to edit that file this milestone
+- all team members have at least one coding task and one writing task
+- will check in Wednesday evening/Thursday morning to see if we need the Thursday meeting this week


### PR DESCRIPTION
M3 retrospective: discussed what did and didn't work during previous milestones, particularly M3
M4 collaboration norms: discussed 5 norms we are committing to for M4 in order to address what did/didn't work in M3, with a focus on the [collaboration feedback for M1, M2, and M3](https://github.com/UBC-MDS/DSCI-532_2026_16_LondonCrime/issues/51)